### PR TITLE
replace embedded readme .gif with remotely hosted .mp4

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The best way to use FFMPEG, conveniently in a single [Livebook](https://livebook
 
 [![Run in Livebook](https://livebook.dev/badge/v1/blue.svg)](https://livebook.dev/run?url=https%3A%2F%2Fraw.githubusercontent.com%2Facalejos%2FCinEx%2Fmain%2Fcinex.livemd)
 
-![demo.gif](demo.gif)
+https://github.com/johnrees/CinEx/assets/601961/05c1ac25-bd5e-4653-ae36-5d7490ab0ef2
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The best way to use FFMPEG, conveniently in a single [Livebook](https://livebook
 
 [![Run in Livebook](https://livebook.dev/badge/v1/blue.svg)](https://livebook.dev/run?url=https%3A%2F%2Fraw.githubusercontent.com%2Facalejos%2FCinEx%2Fmain%2Fcinex.livemd)
 
+![demo.gif](demo.gif)
+
 ## Usage
 
 Simply install Livebook then you can click the **Run in Livebook** badge above to load the file.


### PR DESCRIPTION
If you decide to use this you might want to close this PR and do it yourself @acalejos, as the mp4 URL is based on my fork. You can see it here https://github.com/johnrees/CinEx/tree/readme-video

I just did the following -

- deleted the gif
- ran ffmpeg - I know... I should be doing this in a livebook 🙈  `ffmpeg -i demo.gif -movflags faststart -pix_fmt yuv420p -vf "scale=trunc(iw/2)*2:trunc(ih/2)*2" demo.mp4`
- dragged the file into a github textbox and copied/pasted the URL into the readme

This way you get the benefits of playback controls and no need to store a large binary in the repo. You might want to run something like `git filter-repo --path demo.gif --invert-paths` if you want to remove it from history to keep the repo size lean, but will leave it all up to you!

Thanks for sharing the code!